### PR TITLE
追放機能の追加

### DIFF
--- a/public/logAnalytics.html
+++ b/public/logAnalytics.html
@@ -80,17 +80,19 @@
                 <thead style="text-align: left;">
                     <tr>
                         <th></th>
-                        <th colspan="3">Current</th>
-                        <th colspan="3">Total</th>
+                        <th colspan="4">Current</th>
+                        <th colspan="4">Total</th>
                     </tr>
                     <tr>
                         <th>Name</th>
                         <th>Deck</th>
                         <th>Draw</th>
                         <th>Play</th>
+                        <th>Exile</th>
                         <th>Gain</th>
                         <th>Draw</th>
                         <th>Play</th>
+                        <th>Exile</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -99,6 +101,20 @@
                 <tfoot>
                     <!-- データ行がここに追加されます -->
                 </tfoot>
+            </table>
+
+            <h3>Exile</h3>
+            <table id="FirstPlayerExileAreaTable">
+                <thead style="text-align: left;">
+                    <tr>
+                        <th colspan="2">
+                            Exile
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <!-- データ行がここに追加されます -->
+                </tbody>
             </table>
         </div>
 
@@ -116,9 +132,11 @@
                         <th>Deck</th>
                         <th>Draw</th>
                         <th>Play</th>
+                        <th>Exile</th>
                         <th>Gain</th>
                         <th>Draw</th>
                         <th>Play</th>
+                        <th>Exile</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -127,6 +145,20 @@
                 <tfoot>
                     <!-- データ行がここに追加されます -->
                 </tfoot>
+            </table>
+
+            <h3>Exile</h3>
+            <table id="SecondPlayerExileAreaTable">
+                <thead style="text-align: left;">
+                    <tr>
+                        <th colspan="2">
+                            Exile
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <!-- データ行がここに追加されます -->
+                </tbody>
             </table>
         </div>
 

--- a/public/logAnalytics.html
+++ b/public/logAnalytics.html
@@ -124,8 +124,8 @@
                 <thead style="text-align: left;">
                     <tr>
                         <th></th>
-                        <th colspan="3">Current</th>
-                        <th colspan="3">Total</th>
+                        <th colspan="4">Current</th>
+                        <th colspan="4">Total</th>
                     </tr>
                     <tr>
                         <th>Name</th>

--- a/src/webpack/logic/logAnalyzer/logAnalyzer.ts
+++ b/src/webpack/logic/logAnalyzer/logAnalyzer.ts
@@ -11,6 +11,7 @@ import { plays } from "./methods/plays";
 import { buys } from "./methods/buys";
 import { trashes } from "./methods/trashes";
 import { gains } from "./methods/gains";
+import { exiles, discardFromExile } from "./methods/exile";
 
 interface logSec {
     prevLogSec: LogSectionInterface;
@@ -111,6 +112,8 @@ function analyze(
     if (logArray.length < 2) return;
     const verb = logArray[1];
     const nextOfVerb = logArray[2];
+    const lastTwoWords = logArray.slice(-2).join(" ");
+
 
     // ログの内容によって処理を分岐する
     switch (verb) {
@@ -145,5 +148,17 @@ function analyze(
         case 'trashes':
             trashes(playerMap, logArray, supply);
             break;
+
+        case 'exiles': // カードを追放する
+            exiles(playerMap, logArray, prevLogArray, supply);
+            break
+
+        case 'discards':
+            // 追放していたカードを捨て札にした場合
+            if (lastTwoWords == "from Exile") {
+                discardFromExile(playerMap, logArray);
+                break
+            }
+
     }
 }

--- a/src/webpack/logic/logAnalyzer/methods/cleanUp.ts
+++ b/src/webpack/logic/logAnalyzer/methods/cleanUp.ts
@@ -12,11 +12,13 @@ export function cleanUp(
         // firstPlayerのターンが始まる状態
         secondPlayer.resetTurnPlays();
         secondPlayer.resetTurnDraws();
+        secondPlayer.resetTurnExiles();
         firstPlayer.incrementTurn();
     } else if (firstPlayerTurn > secondPlayerTurn) {
         // secondPlayerのターンが始まる状態
         firstPlayer.resetTurnPlays();
         firstPlayer.resetTurnDraws();
+        firstPlayer.resetTurnExiles();
         secondPlayer.incrementTurn();
     }
 }

--- a/src/webpack/logic/logAnalyzer/methods/exile.ts
+++ b/src/webpack/logic/logAnalyzer/methods/exile.ts
@@ -43,21 +43,26 @@ export function exiles(
             // cardNameがinitialCardCountsに含まれる場合は更新
             if (cardName in initialCardCounts) {                
                 // 追放札にカードを追加
+                // TODO:
+                // 現在Kingdomのカードは半角スペースが省略されて表示されている
+                // 例: Hunting Party -> HuntingParty, Cursed Village -> Cursed Village
+                // そのままカード名を与えても失敗する
+                // プレイヤーのデッキの表示名もバグっていそう(Bounty HunterがHunterと表示されたり)なので
+                // まとめて修正したい
                 player.addToExiles(cardName, count);
                 player.addToTurnExiles(cardName, count);
                 player.addToTotalExiles(cardName, count);
 
                 // サプライからカードを追放した場合はサプライの枚数を減らす
                 // 自分の知る限り、サプライからカードを追放するカードは直前の文章を読んで判別可能
-                // 投資、放逐、包領、輸送、ラクダの隊列、魔女の集会、ラクダの習性、ミミズの修正
-                if (prevLogArray.includes("Invest") ||
-                    prevLogArray.includes("Banish") ||
-                    prevLogArray.includes("Enclave") ||
-                    prevLogArray.includes("Transport") ||
-                    prevLogArray.slice(-2).join(" ") == "Camel Train" || 
-                    prevLogArray.slice(-1).join(" ") == "Coven" || 
-                    prevLogArray.slice(-4).join(" ") == "Way of the Camel" || 
-                    prevLogArray.slice(-4).join(" ") == "Way of the Worm"
+                // 投資、包領、輸送、ラクダの隊列、魔女の集会、ラクダの習性、ミミズの修正
+                if (prevLogArray.slice(-1).join(" ") == "Invest." ||
+                    prevLogArray.slice(-3).join(" ") == "gains a Gold." || // 追放の直前が金貨獲得になるのは包領だけ
+                    prevLogArray.slice(-1).join(" ") == "Transport." ||
+                    prevLogArray.slice(-2).join(" ") == "Camel Train." || 
+                    prevLogArray.slice(-2).join(" ") == "gets +$2." ||  // 追放の直前が+2$になるのは魔女の集会だけ
+                    prevLogArray.slice(-4).join(" ") == "Way of the Camel." || 
+                    prevLogArray.slice(-4).join(" ") == "Way of the Worm."
                 ){
                     supply.decreaseCardCount(cardName, count);
                 } else {
@@ -103,8 +108,8 @@ export function discardFromExile(
 
             // cardNameがinitialCardCountsに含まれる場合は更新
             if (cardName in initialCardCounts) {                
-                // トラッシュエリアは増やす
-                player.removeFromExile(cardName);
+                // 追放エリアのカードを捨て札にする
+                player.discardFromExile(cardName);
             }
         }
     });

--- a/src/webpack/logic/logAnalyzer/methods/exile.ts
+++ b/src/webpack/logic/logAnalyzer/methods/exile.ts
@@ -1,0 +1,111 @@
+import pluralize from 'pluralize';
+import { initialCardCounts } from "../../../enum/initialCardCounts";
+import { Player } from "../../../model/Player";
+import { Supply } from "../../../model/Supply";
+
+export function exiles(
+    playerMap: Map<string, Player>,
+    logArray: string[],
+    prevLogArray: string[],
+    supply: Supply): void {
+
+    // プレイヤーを特定
+    const playerName = logArray[0];
+    const player = playerMap.get(playerName);
+    if (!player) {
+        return;
+    }
+
+    // 例: k plays a Displace. k exiles a Camel Train.
+    // 例: k buys Invest. k exiles a Laboratory. (投資でサプライのカードを追放)
+    // 例: k plays a Camel Train. k exiles a Laboratory.  (ラクダの隊列でサプライのカードを追放)
+    // 例: k plays a Bounty Hunter. k gets +1 Action. k exiles a Copper.  (賞金稼ぎで手札のカードを追放)
+    // 例: k plays a Sanctuary. k draws a Laboratory. k gets +1 Action. k gets +1 Buy. k exiles a Copper. 
+    //     (聖域で手札のカードを追放)
+    let count = 0;
+    let cardName = '';
+    logArray.forEach((text, index) => {
+
+        if (!isNaN(Number(text))) {
+            // textが数字だった場合はcountに代入
+            count = Number(text);
+        } else if(text === 'a' || text === 'an') {
+            // aかanだった場合はcountに1を代入
+            count = 1;
+        } else {
+            try {
+                cardName = pluralize.singular(text);　// 複数形を単数形に変換
+            } catch (e) {
+                console.log(e);
+                cardName = text; // ライブラリが受け付けない入力の場合はそのままの値を使う
+            }
+
+            // cardNameがinitialCardCountsに含まれる場合は更新
+            if (cardName in initialCardCounts) {                
+                // 追放札にカードを追加
+                player.addToExiles(cardName, count);
+                player.addToTurnExiles(cardName, count);
+                player.addToTotalExiles(cardName, count);
+
+                // サプライからカードを追放した場合はサプライの枚数を減らす
+                // 自分の知る限り、サプライからカードを追放するカードは直前の文章を読んで判別可能
+                // 投資、放逐、包領、輸送、ラクダの隊列、魔女の集会、ラクダの習性、ミミズの修正
+                if (prevLogArray.includes("Invest") ||
+                    prevLogArray.includes("Banish") ||
+                    prevLogArray.includes("Enclave") ||
+                    prevLogArray.includes("Transport") ||
+                    prevLogArray.slice(-2).join(" ") == "Camel Train" || 
+                    prevLogArray.slice(-1).join(" ") == "Coven" || 
+                    prevLogArray.slice(-4).join(" ") == "Way of the Camel" || 
+                    prevLogArray.slice(-4).join(" ") == "Way of the Worm"
+                ){
+                    supply.decreaseCardCount(cardName, count);
+                } else {
+                    // 自分のデッキからカードを追放した場合はデッキの枚数を減らす
+                    // 上記以外の追放は全て自分のカードを追放する(はず)
+                    player.decreaseFromNowInDeck(cardName, count);
+                }
+            }
+        }
+    });
+}
+
+export function discardFromExile(
+    playerMap: Map<string, Player>,
+    logArray: string[]): void {
+    
+    // プレイヤーを特定
+    const playerName = logArray[0];
+    const player = playerMap.get(playerName);
+    if (!player) {
+        return;
+    }
+
+    // 例: k discards a Laboratory from Exile.
+    // 例: k discards 3 Stockpiles from Exile. (追放から捨て札にする場合は必ずすべてのカードを捨て札にする)
+    let count = 0;
+    let cardName = '';
+    logArray.forEach((text, index) => {
+
+        if (!isNaN(Number(text))) {
+            // textが数字だった場合はcountに代入
+            count = Number(text);
+        } else if(text === 'a' || text === 'an') {
+            // aかanだった場合はcountに1を代入
+            count = 1;
+        } else {
+            try {
+                cardName = pluralize.singular(text);　// 複数形を単数形に変換
+            } catch (e) {
+                console.log(e);
+                cardName = text; // ライブラリが受け付けない入力の場合はそのままの値を使う
+            }
+
+            // cardNameがinitialCardCountsに含まれる場合は更新
+            if (cardName in initialCardCounts) {                
+                // トラッシュエリアは増やす
+                player.removeFromExile(cardName);
+            }
+        }
+    });
+}

--- a/src/webpack/model/Player.ts
+++ b/src/webpack/model/Player.ts
@@ -12,7 +12,7 @@ export class Player {
     private turnDraws: Map<string, number> = new Map(); // ターン中に引いた合計枚数
     private turnExiles: Map<string, number> = new Map(); // ターン中に追放した合計枚数
     
-    private exileArea: CardInterface[] = [];  // 追放したカード
+    private exileArea: Map<string, number> = new Map();  // 現在の追放エリアの状況
 
     private playerName: string = '';
     private turn: number = 0; // 現在のターン数
@@ -39,6 +39,7 @@ export class Player {
         player.turnDraws = new Map(Array.from(this.turnDraws.entries()).map(([key, card]) => [key, card]));
         player.totalExiles = new Map(Array.from(this.totalExiles.entries()).map(([key, card]) => [key, card]));
         player.turnExiles = new Map(Array.from(this.turnExiles.entries()).map(([key, card]) => [key, card]));
+        player.exileArea = new Map(Array.from(this.exileArea.entries()).map(([key, card]) => [key, card]));
         player.playerName = this.playerName;
         player.turn = this.turn;
         return player;
@@ -166,25 +167,25 @@ export class Player {
     }
     
     // 追放札を取得するメソッド
-    getExileArea(): CardInterface[] {
+    getExileArea(): Map<string, number> {
         return this.exileArea;
     }
 
     // 追放札に新しいカードを追加するメソッド
     addToExiles(cardName: string, count: number): void {
-        const existingCard = this.exileArea.find(card => card.name === cardName);
+        const existingCard = this.exileArea.get(cardName);
         if (existingCard) {
-            existingCard.count += count;
+            this.exileArea.set(cardName, existingCard + count);
         } else {
-            this.exileArea.push({ name: cardName, count });
+            this.exileArea.set(cardName, count);
         }
     }
     
-    // 追放札のカードを取り除くメソッド
-    removeFromExile(cardName: string): void {
-        const existingCard = this.exileArea.find(card => card.name === cardName);
+    // 追放札のカードを捨て札にするメソッド
+    discardFromExile(cardName: string): void {
+        const existingCard = this.exileArea.get(cardName);
         if (existingCard) {
-            existingCard.count = 0;
+            this.exileArea.set(cardName, 0);
         } else {
             // 本来はここに来ないはず
             console.error(`You tried to discard "${cardName}", which does not exist in the exile area.`);

--- a/src/webpack/model/Player.ts
+++ b/src/webpack/model/Player.ts
@@ -1,14 +1,19 @@
+import { CardInterface } from "../interface/CardInterface";
 
 export class Player {
 
     private totalGains: Map<string, number> = new Map(); // ゲーム中に獲得した合計枚数
     private totalPlays: Map<string, number> = new Map(); // ゲーム中にプレイした合計枚数
     private totalDraws: Map<string, number> = new Map(); // ゲーム中に引いた合計枚数
+    private totalExiles: Map<string, number> = new Map(); // ゲーム中に追放した合計枚数
 
     private nowInDeck: Map<string, number> = new Map(); // 現在のデッキ
     private turnPlays: Map<string, number> = new Map(); // ターン中にプレイした合計枚数
     private turnDraws: Map<string, number> = new Map(); // ターン中に引いた合計枚数
+    private turnExiles: Map<string, number> = new Map(); // ターン中に追放した合計枚数
     
+    private exileArea: CardInterface[] = [];  // 追放したカード
+
     private playerName: string = '';
     private turn: number = 0; // 現在のターン数
 
@@ -16,9 +21,11 @@ export class Player {
         this.totalGains.set('card', 0);
         this.totalPlays.set('card', 0);
         this.totalDraws.set('card', 0);
+        this.totalExiles.set('card', 0);
         this.nowInDeck.set('card', 0);
         this.turnPlays.set('card', 0);
         this.turnDraws.set('card', 0);
+        this.turnExiles.set('card', 0);
      }
 
     // ディープコピーを返すメソッド
@@ -30,6 +37,8 @@ export class Player {
         player.turnPlays = new Map(Array.from(this.turnPlays.entries()).map(([key, card]) => [key, card]));
         player.totalDraws = new Map(Array.from(this.totalDraws.entries()).map(([key, card]) => [key, card]));
         player.turnDraws = new Map(Array.from(this.turnDraws.entries()).map(([key, card]) => [key, card]));
+        player.totalExiles = new Map(Array.from(this.totalExiles.entries()).map(([key, card]) => [key, card]));
+        player.turnExiles = new Map(Array.from(this.turnExiles.entries()).map(([key, card]) => [key, card]));
         player.playerName = this.playerName;
         player.turn = this.turn;
         return player;
@@ -154,6 +163,67 @@ export class Player {
         } else {
             this.totalDraws.set(cardName, count);
         }
+    }
+    
+    // 追放札を取得するメソッド
+    getExileArea(): CardInterface[] {
+        return this.exileArea;
+    }
+
+    // 追放札に新しいカードを追加するメソッド
+    addToExiles(cardName: string, count: number): void {
+        const existingCard = this.exileArea.find(card => card.name === cardName);
+        if (existingCard) {
+            existingCard.count += count;
+        } else {
+            this.exileArea.push({ name: cardName, count });
+        }
+    }
+    
+    // 追放札のカードを取り除くメソッド
+    removeFromExile(cardName: string): void {
+        const existingCard = this.exileArea.find(card => card.name === cardName);
+        if (existingCard) {
+            existingCard.count = 0;
+        } else {
+            // 本来はここに来ないはず
+            console.error(`You tried to discard "${cardName}", which does not exist in the exile area.`);
+        }
+    }
+
+    // ターン中に追放した合計枚数を追加するメソッド
+    addToTurnExiles(cardName: string, count: number): void {
+        const existingCard = this.turnExiles.get(cardName);
+        if (existingCard) {
+            this.turnExiles.set(cardName, existingCard + count);
+        } else {
+            this.turnExiles.set(cardName, count);
+        }
+    }
+
+    // ターン中に追放した合計枚数をリセットするメソッド
+    resetTurnExiles(): void{
+        this.turnExiles = new Map();
+    }
+
+    // ターン中に追放した合計枚数を取得するメソッド
+    getTurnExiles(): Map<string, number> {
+        return this.turnExiles;
+    }
+
+    // ゲーム中に追放した合計枚数を追加するメソッド
+    addToTotalExiles(cardName: string, count: number): void {
+        const existingCard = this.totalExiles.get(cardName);
+        if (existingCard) {
+            this.totalExiles.set(cardName, existingCard + count);
+        } else {
+            this.totalExiles.set(cardName, count);
+        }
+    }
+
+    // ゲーム中に追放した合計枚数を取得するメソッド
+    getTotalExiles(): Map<string, number> {
+        return this.totalExiles;
     }
 
     // プレイヤー名を取得するメソッド

--- a/src/webpack/screenEvent/logAnalitics/updateScreen.ts
+++ b/src/webpack/screenEvent/logAnalitics/updateScreen.ts
@@ -336,19 +336,19 @@ function updatePlayerArea(
         }
 
         // テーブルの再描画
-        player.getExileArea().forEach(card => {
+        player.getExileArea().forEach((count, name) => {
             const row = playerExileTableBody.insertRow();
             const cell1 = row.insertCell(0);
             const cell2 = row.insertCell(1);
-            cell1.textContent = card.name;
-            cell2.textContent = card.count.toString();
+            cell1.textContent = name;
+            cell2.textContent = count.toString();
 
 
             // 増減したカードの背景色を変更
-            const prevCount = prevPlayer.getExileArea().find(c => c.name === card.name)?.count || 0;
-            cell2.style.backgroundColor = getBackgroundColor(card.count, prevCount);
-            if (card.count !== prevCount) {
-                cell2.textContent = prevCount + "→" + card.count;
+            const prevCount = prevPlayer.getExileArea().get(name) || 0;
+            cell2.style.backgroundColor = getBackgroundColor(count, prevCount);
+            if (count !== prevCount) {
+                cell2.textContent = prevCount + "→" + count;
             }
         });
     }

--- a/src/webpack/screenEvent/logAnalitics/updateScreen.ts
+++ b/src/webpack/screenEvent/logAnalitics/updateScreen.ts
@@ -191,14 +191,14 @@ function updatePlayerArea(
             " / " + lastPlayer.getTurn().toString();
     }
 
-    // テーブルの更新
+    // デッキテーブルの更新
     const prevPlayer = playerSwitch === 1 ? prevGameLog.firstPlayer : prevGameLog.secondPlayer;
-    const tableElement = playerSwitch === 1 ? 'FirstPlayerDeckTable' : 'SecondPlayerDeckTable';
+    const deckTableElement = playerSwitch === 1 ? 'FirstPlayerDeckTable' : 'SecondPlayerDeckTable';
 
-    const playerDeckTableBody = document.getElementById(tableElement)?.getElementsByTagName('tbody')[0];
-    let firstPlayerSum = new Array(7).fill(0);
+    const playerDeckTableBody = document.getElementById(deckTableElement)?.getElementsByTagName('tbody')[0];
+    let firstPlayerSum = new Array(8).fill(0);
     if (playerDeckTableBody) {
-        // テーブルのリセット
+        // デッキテーブルのリセット
         while (playerDeckTableBody.firstChild) {
             playerDeckTableBody.removeChild(playerDeckTableBody.firstChild);
         }
@@ -213,42 +213,50 @@ function updatePlayerArea(
             const cell5 = row.insertCell(4);
             const cell6 = row.insertCell(5);
             const cell7 = row.insertCell(6);
+            const cell8 = row.insertCell(7);
+            const cell9 = row.insertCell(8);
 
             const nowInDeck = player.getNowInDeck().get(index) || 0;
             const turnDraws = player.getTurnDraws().get(index) || 0;
             const turnPlays = player.getTurnPlays().get(index) || 0;
+            const turnExiles = player.getTurnExiles().get(index) || 0;
 
             const totalGains = player.getTotalGains().get(index) || 0;
             const totalDraws = player.getTotalDraws().get(index) || 0;
             const totalPlays = player.getTotalPlays().get(index) || 0;
+            const totalExiles = player.getTotalExiles().get(index) || 0;
 
             cell1.textContent = index.toString();
 
             cell2.textContent = nowInDeck.toString();
             cell3.textContent = turnDraws.toString();
             cell4.textContent = turnPlays.toString();
+            cell5.textContent = turnExiles.toString()
 
-            cell5.textContent = totalGains.toString();
-            cell6.textContent = totalDraws.toString();
-            cell7.textContent = totalPlays.toString();
-
+            cell6.textContent = totalGains.toString();
+            cell7.textContent = totalDraws.toString();
+            cell8.textContent = totalPlays.toString();
+            cell9.textContent = totalExiles.toString();
 
             firstPlayerSum[0] += nowInDeck;
             firstPlayerSum[1] += turnDraws;
             firstPlayerSum[2] += turnPlays;
-            firstPlayerSum[3] += totalGains;
-            firstPlayerSum[4] += totalDraws;
-            firstPlayerSum[5] += totalPlays;
-            firstPlayerSum[6] += totalGains;
+            firstPlayerSum[3] += turnExiles;
+            firstPlayerSum[4] += totalGains;
+            firstPlayerSum[5] += totalDraws;
+            firstPlayerSum[6] += totalPlays;
+            firstPlayerSum[7] += totalExiles;
 
             // 増減したカードの背景色を変更
             const prevNowInDeck = prevPlayer.getNowInDeck().get(index) || 0;
             const prevTurnDraws = prevPlayer.getTurnDraws().get(index) || 0;
             const prevTurnPlays = prevPlayer.getTurnPlays().get(index) || 0;
+            const prevTurnExiles = prevPlayer.getTurnExiles().get(index) || 0;
 
             const prevTotalGains = prevPlayer.getTotalGains().get(index) || 0;
             const prevTotalDraws = prevPlayer.getTotalDraws().get(index) || 0;
             const prevTotalPlays = prevPlayer.getTotalPlays().get(index) || 0;
+            const prevTotalExiles = prevPlayer.getTotalExiles().get(index) || 0;
 
 
             if (nowInDeck !== prevNowInDeck) {
@@ -263,24 +271,32 @@ function updatePlayerArea(
                 cell4.style.backgroundColor = getBackgroundColor(turnPlays, prevTurnPlays);
                 cell4.textContent = prevTurnPlays + "→" + turnPlays.toString();
             }
+            if (turnExiles !== prevTurnExiles) {
+                cell5.style.backgroundColor = getBackgroundColor(turnExiles, prevTurnExiles);
+                cell5.textContent = prevTurnExiles + "→" + turnExiles.toString();
+            }
 
             /*
             WIP：合計系は色を変えない方が観易いかもしれないので一旦コメントアウト
             if (totalGains !== prevTotalGains) {
-                cell5.style.backgroundColor = getBackgroundColor(totalGains, prevTotalGains);
-                cell5.textContent = prevTotalGains + "→" + totalGains;
+                cell6.style.backgroundColor = getBackgroundColor(totalGains, prevTotalGains);
+                cell6.textContent = prevTotalGains + "→" + totalGains;
             }
             if (totalDraws !== prevTotalDraws) {
-                cell6.style.backgroundColor = getBackgroundColor(totalDraws, prevTotalDraws);
-                cell6.textContent = prevTotalDraws + "→" + totalDraws.toString();
+                cell7.style.backgroundColor = getBackgroundColor(totalDraws, prevTotalDraws);
+                cell7.textContent = prevTotalDraws + "→" + totalDraws.toString();
             }
             if (totalPlays !== prevTotalPlays) {
-                cell7.style.backgroundColor = getBackgroundColor(totalPlays, prevTotalPlays);
-                cell7.textContent = prevTotalPlays + "→" + totalPlays.toString();
+                cell8.style.backgroundColor = getBackgroundColor(totalPlays, prevTotalPlays);
+                cell8.textContent = prevTotalPlays + "→" + totalPlays.toString();
+            }
+            if (totalExiles !== prevTotalExiles) {
+                cell9.style.backgroundColor = getBackgroundColor(totalExiles, prevTotalExiles);
+                cell9.textContent = prevTotalExiles + "→" + totalExiles.toString();
             }*/
         });
     }
-    const playerDeckTableFoot = document.getElementById(tableElement)?.getElementsByTagName('tfoot')[0];
+    const playerDeckTableFoot = document.getElementById(deckTableElement)?.getElementsByTagName('tfoot')[0];
     if (playerDeckTableFoot) {
         // テーブルのリセット
         while (playerDeckTableFoot.firstChild) {
@@ -296,14 +312,45 @@ function updatePlayerArea(
         const cell5 = row.insertCell(4);
         const cell6 = row.insertCell(5);
         const cell7 = row.insertCell(6);
+        const cell8 = row.insertCell(7);
+        const cell9 = row.insertCell(8);
 
         cell1.textContent = "Sum";
-        cell2.textContent = firstPlayerSum[0].toString();
-        cell3.textContent = firstPlayerSum[1].toString();
-        cell4.textContent = firstPlayerSum[2].toString();
-        cell5.textContent = firstPlayerSum[3].toString();
-        cell6.textContent = firstPlayerSum[4].toString();
-        cell7.textContent = firstPlayerSum[5].toString();
+        cell2.textContent = firstPlayerSum[0].toString();  // nowInDeck
+        cell3.textContent = firstPlayerSum[1].toString();  // turnDraws
+        cell4.textContent = firstPlayerSum[2].toString();  // turnPlays
+        cell5.textContent = firstPlayerSum[3].toString();  // turnExiles
+        cell6.textContent = firstPlayerSum[4].toString();  // totalGains
+        cell7.textContent = firstPlayerSum[5].toString();  // totalDraws
+        cell8.textContent = firstPlayerSum[6].toString();  // totalPlays
+        cell9.textContent = firstPlayerSum[7].toString();  // totalExiles
+    }
+
+    // 追放エリアテーブルの更新
+    const exileTableElement = playerSwitch === 1 ? 'FirstPlayerExileAreaTable' : 'SecondPlayerExileAreaTable';
+    const playerExileTableBody = document.getElementById(exileTableElement)?.getElementsByTagName('tbody')[0];
+    if (playerExileTableBody) {
+        // テーブルのリセット
+        while (playerExileTableBody.firstChild) {
+            playerExileTableBody.removeChild(playerExileTableBody.firstChild);
+        }
+
+        // テーブルの再描画
+        player.getExileArea().forEach(card => {
+            const row = playerExileTableBody.insertRow();
+            const cell1 = row.insertCell(0);
+            const cell2 = row.insertCell(1);
+            cell1.textContent = card.name;
+            cell2.textContent = card.count.toString();
+
+
+            // 増減したカードの背景色を変更
+            const prevCount = prevPlayer.getExileArea().find(c => c.name === card.name)?.count || 0;
+            cell2.style.backgroundColor = getBackgroundColor(card.count, prevCount);
+            if (card.count !== prevCount) {
+                cell2.textContent = prevCount + "→" + card.count;
+            }
+        });
     }
 }
 


### PR DESCRIPTION
## 概要
- 追放機能を実装しました 
  - 指定したタイミングでの追放されているカードを表示
  - 現在のターン / ゲーム中の追放したカードの記録 

- 参考イメージ
![スクリーンショット 2025-03-13 21 03 39](https://github.com/user-attachments/assets/baba7012-bf64-45ad-983a-6e51e8eae45e)
![スクリーンショット 2025-03-13 21 01 56](https://github.com/user-attachments/assets/fee85ca1-02e4-4fbb-aa0f-8425b22adbe2)
![スクリーンショット 2025-03-13 21 01 33](https://github.com/user-attachments/assets/9b1d6fa3-2724-4879-90d2-f2140ef7eeb8)


## 関連issue
#2 

## 変更点
- public/logAnalytics.html ：追放の表示欄を追加
- src/webpack/model/Player.ts　：追放用の変数・入出力メソッドの追加
- src/webpack/screenEvent/logAnalitics/updateScreen.ts　：Playersの追放情報を画面に反映させるロジックの追加
- src/webpack/logic/logAnalyzer/logAnalyzer.ts　：caseにexileを追加
- src/webpack/logic/logAnalyzer/methods　：exile.tsを追加
- src/webpack/logic/logAnalyzer/cleanUp.ts：exileの状態のリセット処理の追加

## 影響範囲
- 変更点を参照

## 補足
- 自分のカードとサプライのカード、どちらを追放するのか判別するためにややロジックが汚くなってます...
- 現在、自分のデッキのカードは複数単語からなるカード(Bounty Hunterなど)がうまく表示できない？
  - それに関係しているか不明ですが複数単語からなるカードを追放したときに挙動が安定しないため、上記の問題ともに解決したいです
    - このPRでは追放機能の実装方針についてレビューしていただきたいです
