### PR TITLE
feat: Add admin panel with delete functionality for game logs and com…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "sanitize-html": "^2.14.0",
         "ts-loader": "^9.5.1",
         "ts-node": "^10.9.2",
-        "typescript": "^5.7.3",
+        "typescript": "^5.8.3",
         "webpack": "^5.96.1",
         "webpack-cli": "^5.1.4"
       },
@@ -2915,9 +2915,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "sanitize-html": "^2.14.0",
     "ts-loader": "^9.5.1",
     "ts-node": "^10.9.2",
-    "typescript": "^5.7.3",
+    "typescript": "^5.8.3",
     "webpack": "^5.96.1",
     "webpack-cli": "^5.1.4"
   },

--- a/public/admin.html
+++ b/public/admin.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Admin Panel - DominionKifu</title>
+    <link rel="stylesheet" href="./css/styles.css">
+    <link rel="stylesheet" href="./css/admin.css">
+</head>
+
+<body>
+    <div class="menu">
+        <li><a href="gameDataInput.html">Home</a></li>
+        <li><a href="admin.html">Admin</a></li>
+    </div>
+
+    <div id="MainContent">
+        <!-- 認証セクション -->
+        <div id="AuthSection" class="section">
+            <h2>Admin Authentication</h2>
+            <div class="form-group">
+                <label for="adminPassword">Admin Password:</label>
+                <input type="password" id="adminPassword" placeholder="Enter admin password">
+                <button id="loginButton">Login</button>
+            </div>
+            <div id="authMessage" class="message"></div>
+        </div>
+
+        <!-- 管理パネル（認証後に表示） -->
+        <div id="AdminPanel" class="section" style="display: none;">
+            <h2>Admin Panel</h2>
+            
+            <!-- ゲームログ管理 -->
+            <div class="admin-section">
+                <h3>Game Log Management</h3>
+                <div id="gameLogList">
+                    <table id="gameLogTable">
+                        <thead>
+                            <tr>
+                                <th>Game Number</th>
+                                <th>Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <!-- ゲームログ一覧がここに表示されます -->
+                        </tbody>
+                    </table>
+                </div>
+                <button id="refreshGameLogs">Refresh Game Logs</button>
+            </div>
+
+            <!-- コメント管理 -->
+            <div class="admin-section">
+                <h3>Comment Management</h3>
+                <div id="commentList">
+                    <table id="commentTable">
+                        <thead>
+                            <tr>
+                                <th>Game Number</th>
+                                <th>Pointer</th>
+                                <th>User</th>
+                                <th>Comment</th>
+                                <th>Date</th>
+                                <th>Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <!-- コメント一覧がここに表示されます -->
+                        </tbody>
+                    </table>
+                </div>
+                <button id="refreshComments">Refresh Comments</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- 確認ダイアログ -->
+    <div id="confirmDialog" class="modal" style="display: none;">
+        <div class="modal-content">
+            <h3>Confirm Deletion</h3>
+            <p id="confirmMessage"></p>
+            <div class="modal-buttons">
+                <button id="confirmYes" class="btn-danger">Yes, Delete</button>
+                <button id="confirmNo" class="btn-cancel">Cancel</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- スクリプト定義 -->
+    <script src="./dist/screenEvent/admin/adminController.bundle.js"></script>
+</body>
+
+</html>

--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -1,0 +1,176 @@
+/* Admin Panel Styles */
+
+.section {
+    margin-bottom: 30px;
+    padding: 20px;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    background-color: #f9f9f9;
+}
+
+.admin-section {
+    margin-bottom: 20px;
+    padding: 15px;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    background-color: white;
+}
+
+.form-group {
+    margin-bottom: 15px;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 5px;
+    font-weight: bold;
+}
+
+.form-group input {
+    width: 200px;
+    padding: 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    margin-right: 10px;
+}
+
+.form-group button {
+    padding: 8px 15px;
+    background-color: #007bff;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.form-group button:hover {
+    background-color: #0056b3;
+}
+
+.message {
+    margin-top: 10px;
+    padding: 10px;
+    border-radius: 4px;
+    display: none;
+}
+
+.message.success {
+    background-color: #d4edda;
+    color: #155724;
+    border: 1px solid #c3e6cb;
+}
+
+.message.error {
+    background-color: #f8d7da;
+    color: #721c24;
+    border: 1px solid #f5c6cb;
+}
+
+/* Table styles */
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 15px;
+}
+
+table th,
+table td {
+    padding: 10px;
+    text-align: left;
+    border-bottom: 1px solid #ddd;
+}
+
+table th {
+    background-color: #f2f2f2;
+    font-weight: bold;
+}
+
+table tr:hover {
+    background-color: #f5f5f5;
+}
+
+/* Button styles */
+button {
+    padding: 6px 12px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    margin-right: 5px;
+}
+
+button.btn-danger {
+    background-color: #dc3545;
+    color: white;
+}
+
+button.btn-danger:hover {
+    background-color: #c82333;
+}
+
+button.btn-cancel {
+    background-color: #6c757d;
+    color: white;
+}
+
+button.btn-cancel:hover {
+    background-color: #5a6268;
+}
+
+button.btn-primary {
+    background-color: #007bff;
+    color: white;
+}
+
+button.btn-primary:hover {
+    background-color: #0056b3;
+}
+
+/* Modal styles */
+.modal {
+    position: fixed;
+    z-index: 1000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+}
+
+.modal-content {
+    background-color: white;
+    margin: 15% auto;
+    padding: 20px;
+    border-radius: 8px;
+    width: 300px;
+    text-align: center;
+}
+
+.modal-buttons {
+    margin-top: 20px;
+}
+
+.modal-buttons button {
+    margin: 0 5px;
+}
+
+/* Responsive design */
+@media (max-width: 768px) {
+    .form-group input {
+        width: 100%;
+        margin-bottom: 10px;
+    }
+    
+    .modal-content {
+        width: 90%;
+        margin: 10% auto;
+    }
+    
+    table {
+        font-size: 12px;
+    }
+    
+    table th,
+    table td {
+        padding: 5px;
+    }
+}

--- a/src/server/controller/authController.ts
+++ b/src/server/controller/authController.ts
@@ -1,0 +1,28 @@
+import express, { Request, Response } from 'express';
+import { checkAdminCredentials } from '../middleware/authMiddleware';
+
+export function authController(app: express.Application) {
+    
+    // 管理者認証エンドポイント
+    app.post('/api/admin/login', (req: Request, res: Response) => {
+        const { password } = req.body;
+        
+        if (!password) {
+            return res.status(400).json({ error: 'Password is required' });
+        }
+        
+        if (checkAdminCredentials(password)) {
+            // 簡単なトークンとして、パスワードをそのまま返す
+            res.json({ 
+                success: true, 
+                token: password,
+                message: 'Admin authentication successful' 
+            });
+        } else {
+            res.status(401).json({ 
+                success: false, 
+                error: 'Invalid admin password' 
+            });
+        }
+    });
+}

--- a/src/server/controller/authController.ts
+++ b/src/server/controller/authController.ts
@@ -4,11 +4,12 @@ import { checkAdminCredentials } from '../middleware/authMiddleware';
 export function authController(app: express.Application) {
     
     // 管理者認証エンドポイント
-    app.post('/api/admin/login', (req: Request, res: Response) => {
+    app.post('/api/admin/login', (req: Request, res: Response): void => {
         const { password } = req.body;
         
         if (!password) {
-            return res.status(400).json({ error: 'Password is required' });
+            res.status(400).json({ error: 'Password is required' });
+            return;
         }
         
         if (checkAdminCredentials(password)) {

--- a/src/server/controller/commentController.ts
+++ b/src/server/controller/commentController.ts
@@ -1,6 +1,7 @@
-import { searchComment, searchAllComment, insertComment } from '../repository/commentRepository';
+import { searchComment, searchAllComment, insertComment, deleteComment } from '../repository/commentRepository';
 import { CommentInterface } from '../../webpack/interface/CommentInterface';
 import express, { Request, Response } from 'express';
+import { adminAuth } from '../middleware/authMiddleware';
 
 export function commentController(app: express.Application) {
     
@@ -37,5 +38,24 @@ export function commentController(app: express.Application) {
     app.get('/api/all/comment', (req: Request, res: Response) => {
         const commentArray = searchAllComment();
         res.json(commentArray);
+    });
+
+    // コメント削除エンドポイント（管理者のみ）
+    app.delete('/api/comment/:gameNumber/:pointer', adminAuth, (req: Request, res: Response) => {
+        // リクエストパラメータからデータを取得
+        const gameNumber = req.params.gameNumber as string;
+        const pointer = parseInt(req.params.pointer);
+
+        // データベースからデータを削除
+        if (gameNumber && !isNaN(pointer)) {
+            const result = deleteComment(gameNumber, pointer);
+            if (result) {
+                res.send('Comment is deleted.');
+            } else {
+                res.status(404).send('Comment not found');
+            }
+        } else {
+            res.status(400).send('Game number and pointer are required');
+        }
     });
 }

--- a/src/server/controller/gameLogController.ts
+++ b/src/server/controller/gameLogController.ts
@@ -1,6 +1,7 @@
-import { searchGameLog, insertGameLog, searchAllGameLog, searchAllGameNumber } from '../repository/gameLogRepository';
+import { searchGameLog, insertGameLog, searchAllGameLog, searchAllGameNumber, deleteGameLog } from '../repository/gameLogRepository';
 import { GameLogInterface } from '../../webpack/interface/GameLogInterface';
 import express, { Request, Response } from 'express';
+import { adminAuth } from '../middleware/authMiddleware';
 
 export function gameLogController(app: express.Application) {
     // ゲームデータ取得エンドポイント
@@ -42,5 +43,23 @@ export function gameLogController(app: express.Application) {
     app.get('/api/all/gamenumber', (req: Request, res: Response) => {
         const gameNumberArray = searchAllGameNumber();
         res.json(gameNumberArray);
+    });
+
+    // ゲームデータ削除エンドポイント（管理者のみ）
+    app.delete('/api/gamelog/:gameNumber', adminAuth, (req: Request, res: Response) => {
+        // リクエストパラメータからデータを取得
+        const gameNumber = req.params.gameNumber as string;
+
+        // データベースからデータを削除
+        if (gameNumber) {
+            const result = deleteGameLog(gameNumber);
+            if (result) {
+                res.send('Game log is deleted.');
+            } else {
+                res.status(404).send('Game data not found');
+            }
+        } else {
+            res.status(400).send('Game number is required');
+        }
     });
 }

--- a/src/server/controller/index.ts
+++ b/src/server/controller/index.ts
@@ -3,6 +3,7 @@ import { startDb } from '../database/makeLokiDb';
 import cors from 'cors';
 import { gameLogController } from './gameLogController';
 import { commentController } from './commentController';
+import { authController } from './authController';
 import path from 'path';
 
 const app = express();
@@ -27,6 +28,9 @@ gameLogController(app);
 
 // Commentのエンドポイント
 commentController(app);
+
+// 認証のエンドポイント
+authController(app);
 
 // サーバの起動
 app.listen(port, () => {

--- a/src/server/middleware/authMiddleware.ts
+++ b/src/server/middleware/authMiddleware.ts
@@ -1,0 +1,28 @@
+import { Request, Response, NextFunction } from 'express';
+
+interface AuthenticatedRequest extends Request {
+    isAdmin?: boolean;
+}
+
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'dominion-admin-2024';
+
+export function adminAuth(req: AuthenticatedRequest, res: Response, next: NextFunction) {
+    const authHeader = req.headers.authorization;
+    
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+        return res.status(401).json({ error: 'Unauthorized: No token provided' });
+    }
+    
+    const token = authHeader.substring(7);
+    
+    if (token !== ADMIN_PASSWORD) {
+        return res.status(403).json({ error: 'Forbidden: Invalid admin token' });
+    }
+    
+    req.isAdmin = true;
+    next();
+}
+
+export function checkAdminCredentials(password: string): boolean {
+    return password === ADMIN_PASSWORD;
+}

--- a/src/server/middleware/authMiddleware.ts
+++ b/src/server/middleware/authMiddleware.ts
@@ -6,17 +6,19 @@ interface AuthenticatedRequest extends Request {
 
 const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'dominion-admin-2024';
 
-export function adminAuth(req: AuthenticatedRequest, res: Response, next: NextFunction) {
+export function adminAuth(req: AuthenticatedRequest, res: Response, next: NextFunction): void {
     const authHeader = req.headers.authorization;
     
     if (!authHeader || !authHeader.startsWith('Bearer ')) {
-        return res.status(401).json({ error: 'Unauthorized: No token provided' });
+        res.status(401).json({ error: 'Unauthorized: No token provided' });
+        return;
     }
     
     const token = authHeader.substring(7);
     
     if (token !== ADMIN_PASSWORD) {
-        return res.status(403).json({ error: 'Forbidden: Invalid admin token' });
+        res.status(403).json({ error: 'Forbidden: Invalid admin token' });
+        return;
     }
     
     req.isAdmin = true;

--- a/src/server/repository/commentRepository.ts
+++ b/src/server/repository/commentRepository.ts
@@ -29,3 +29,20 @@ export function insertComment(comment: CommentInterface) {
     commentCollection.insert(comment);
     db.saveDatabase();
 }
+
+export function deleteComment(gameNumber: string, pointer: number): boolean {
+    // インジェクション対策
+    const sanitizedGameNumber = sanitizeInput(gameNumber);
+    
+    const db = getDb();
+    const commentCollection = db.getCollection<CommentInterface>('comment');
+    const comment = commentCollection.findOne({ gameNumber: sanitizedGameNumber, pointer: pointer });
+    
+    if (comment) {
+        commentCollection.remove(comment);
+        db.saveDatabase();
+        return true;
+    }
+    
+    return false;
+}

--- a/src/server/repository/gameLogRepository.ts
+++ b/src/server/repository/gameLogRepository.ts
@@ -35,3 +35,20 @@ export function insertGameLog(gameLog: GameLogInterface): void {
     gameLogCollection.insert(gameLog);
     db.saveDatabase();
 }
+
+export function deleteGameLog(gameNumber: string): boolean {
+    // インジェクション対策
+    const sanitizedGameNumber = sanitizeInput(gameNumber);
+    
+    const db = getDb();
+    const gameLogCollection = db.getCollection<GameLogInterface>('gameLog');
+    const gameLog = gameLogCollection.findOne({ gameNumber: sanitizedGameNumber });
+    
+    if (gameLog) {
+        gameLogCollection.remove(gameLog);
+        db.saveDatabase();
+        return true;
+    }
+    
+    return false;
+}

--- a/src/webpack/logic/callApi/adminLogin.ts
+++ b/src/webpack/logic/callApi/adminLogin.ts
@@ -1,0 +1,26 @@
+import axios from 'axios';
+
+interface LoginResponse {
+    success: boolean;
+    token?: string;
+    message?: string;
+    error?: string;
+}
+
+export async function adminLoginApi(password: string): Promise<LoginResponse> {
+    try {
+        const response = await axios.post('/api/admin/login', {
+            password: password
+        });
+        
+        return response.data;
+    } catch (error) {
+        if (axios.isAxiosError(error) && error.response) {
+            return {
+                success: false,
+                error: error.response.data.error || 'Login failed'
+            };
+        }
+        throw error;
+    }
+}

--- a/src/webpack/logic/callApi/deleteComment.ts
+++ b/src/webpack/logic/callApi/deleteComment.ts
@@ -1,0 +1,26 @@
+import axios from 'axios';
+
+export async function deleteCommentApi(gameNumber: string, pointer: number, adminToken: string): Promise<void> {
+    try {
+        const response = await axios.delete(`/api/comment/${gameNumber}/${pointer}`, {
+            headers: {
+                'Authorization': `Bearer ${adminToken}`
+            }
+        });
+        
+        if (response.status !== 200) {
+            throw new Error(`Failed to delete comment: ${response.statusText}`);
+        }
+    } catch (error) {
+        if (axios.isAxiosError(error)) {
+            if (error.response?.status === 401) {
+                throw new Error('Unauthorized: Invalid admin token');
+            } else if (error.response?.status === 404) {
+                throw new Error('Comment not found');
+            } else {
+                throw new Error(`Failed to delete comment: ${error.response?.data || error.message}`);
+            }
+        }
+        throw error;
+    }
+}

--- a/src/webpack/logic/callApi/deleteGameLog.ts
+++ b/src/webpack/logic/callApi/deleteGameLog.ts
@@ -1,0 +1,26 @@
+import axios from 'axios';
+
+export async function deleteGameLogApi(gameNumber: string, adminToken: string): Promise<void> {
+    try {
+        const response = await axios.delete(`/api/gamelog/${gameNumber}`, {
+            headers: {
+                'Authorization': `Bearer ${adminToken}`
+            }
+        });
+        
+        if (response.status !== 200) {
+            throw new Error(`Failed to delete game log: ${response.statusText}`);
+        }
+    } catch (error) {
+        if (axios.isAxiosError(error)) {
+            if (error.response?.status === 401) {
+                throw new Error('Unauthorized: Invalid admin token');
+            } else if (error.response?.status === 404) {
+                throw new Error('Game log not found');
+            } else {
+                throw new Error(`Failed to delete game log: ${error.response?.data || error.message}`);
+            }
+        }
+        throw error;
+    }
+}

--- a/src/webpack/logic/callApi/getAllComments.ts
+++ b/src/webpack/logic/callApi/getAllComments.ts
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+interface Comment {
+    gameNumber: string;
+    pointer: number;
+    comment: string;
+    userName: string;
+    date: string;
+}
+
+export async function getAllCommentsApi(): Promise<Comment[]> {
+    try {
+        const response = await axios.get('/api/all/comment');
+        return response.data;
+    } catch (error) {
+        console.error('Failed to fetch all comments:', error);
+        throw new Error('Failed to fetch comments');
+    }
+}

--- a/src/webpack/screenEvent/admin/adminController.ts
+++ b/src/webpack/screenEvent/admin/adminController.ts
@@ -1,6 +1,6 @@
 import { deleteGameLogApi } from '../../logic/callApi/deleteGameLog';
 import { deleteCommentApi } from '../../logic/callApi/deleteComment';
-import { getGameNumberListApi } from '../../logic/callApi/getGameNumberList';
+import { getGameNumberList } from '../../logic/callApi/getGameNumberList';
 import { getAllCommentsApi } from '../../logic/callApi/getAllComments';
 import { adminLoginApi } from '../../logic/callApi/adminLogin';
 
@@ -54,7 +54,7 @@ async function handleLogin() {
     try {
         const result = await adminLoginApi(password);
         if (result.success) {
-            adminToken = result.token;
+            adminToken = result.token || null;
             showAdminPanel();
             showMessage('Login successful', 'success');
             await loadGameLogs();
@@ -91,7 +91,7 @@ async function loadGameLogs() {
     if (!adminToken) return;
 
     try {
-        const gameNumbers = await getGameNumberListApi();
+        const gameNumbers = await getGameNumberList();
         const tableBody = document.querySelector('#gameLogTable tbody') as HTMLTableSectionElement;
         
         tableBody.innerHTML = '';

--- a/src/webpack/screenEvent/admin/adminController.ts
+++ b/src/webpack/screenEvent/admin/adminController.ts
@@ -1,0 +1,194 @@
+import { deleteGameLogApi } from '../../logic/callApi/deleteGameLog';
+import { deleteCommentApi } from '../../logic/callApi/deleteComment';
+import { getGameNumberListApi } from '../../logic/callApi/getGameNumberList';
+import { getAllCommentsApi } from '../../logic/callApi/getAllComments';
+import { adminLoginApi } from '../../logic/callApi/adminLogin';
+
+let adminToken: string | null = null;
+
+interface Comment {
+    gameNumber: string;
+    pointer: number;
+    comment: string;
+    userName: string;
+    date: string;
+}
+
+// 初期化処理
+document.addEventListener('DOMContentLoaded', () => {
+    initializeAdminPanel();
+});
+
+function initializeAdminPanel() {
+    const loginButton = document.getElementById('loginButton') as HTMLButtonElement;
+    const refreshGameLogsButton = document.getElementById('refreshGameLogs') as HTMLButtonElement;
+    const refreshCommentsButton = document.getElementById('refreshComments') as HTMLButtonElement;
+    const confirmYesButton = document.getElementById('confirmYes') as HTMLButtonElement;
+    const confirmNoButton = document.getElementById('confirmNo') as HTMLButtonElement;
+
+    loginButton.addEventListener('click', handleLogin);
+    refreshGameLogsButton.addEventListener('click', loadGameLogs);
+    refreshCommentsButton.addEventListener('click', loadComments);
+    confirmYesButton.addEventListener('click', handleConfirmYes);
+    confirmNoButton.addEventListener('click', hideConfirmDialog);
+
+    // パスワード入力でEnterキーを押した場合のログイン
+    const passwordInput = document.getElementById('adminPassword') as HTMLInputElement;
+    passwordInput.addEventListener('keypress', (e) => {
+        if (e.key === 'Enter') {
+            handleLogin();
+        }
+    });
+}
+
+async function handleLogin() {
+    const passwordInput = document.getElementById('adminPassword') as HTMLInputElement;
+    const password = passwordInput.value.trim();
+    const messageDiv = document.getElementById('authMessage') as HTMLDivElement;
+
+    if (!password) {
+        showMessage('Please enter admin password', 'error');
+        return;
+    }
+
+    try {
+        const result = await adminLoginApi(password);
+        if (result.success) {
+            adminToken = result.token;
+            showAdminPanel();
+            showMessage('Login successful', 'success');
+            await loadGameLogs();
+            await loadComments();
+        } else {
+            showMessage('Invalid admin password', 'error');
+        }
+    } catch (error) {
+        showMessage('Login failed', 'error');
+        console.error('Login error:', error);
+    }
+}
+
+function showAdminPanel() {
+    const authSection = document.getElementById('AuthSection') as HTMLDivElement;
+    const adminPanel = document.getElementById('AdminPanel') as HTMLDivElement;
+    
+    authSection.style.display = 'none';
+    adminPanel.style.display = 'block';
+}
+
+function showMessage(message: string, type: 'success' | 'error') {
+    const messageDiv = document.getElementById('authMessage') as HTMLDivElement;
+    messageDiv.textContent = message;
+    messageDiv.className = `message ${type}`;
+    messageDiv.style.display = 'block';
+    
+    setTimeout(() => {
+        messageDiv.style.display = 'none';
+    }, 3000);
+}
+
+async function loadGameLogs() {
+    if (!adminToken) return;
+
+    try {
+        const gameNumbers = await getGameNumberListApi();
+        const tableBody = document.querySelector('#gameLogTable tbody') as HTMLTableSectionElement;
+        
+        tableBody.innerHTML = '';
+        
+        gameNumbers.forEach((gameNumber: string) => {
+            const row = document.createElement('tr');
+            row.innerHTML = `
+                <td>${gameNumber}</td>
+                <td>
+                    <button class="btn-danger" onclick="confirmDeleteGameLog('${gameNumber}')">Delete</button>
+                </td>
+            `;
+            tableBody.appendChild(row);
+        });
+    } catch (error) {
+        console.error('Failed to load game logs:', error);
+        alert('Failed to load game logs');
+    }
+}
+
+async function loadComments() {
+    if (!adminToken) return;
+
+    try {
+        const comments = await getAllCommentsApi();
+        const tableBody = document.querySelector('#commentTable tbody') as HTMLTableSectionElement;
+        
+        tableBody.innerHTML = '';
+        
+        comments.forEach((comment: Comment) => {
+            const row = document.createElement('tr');
+            row.innerHTML = `
+                <td>${comment.gameNumber}</td>
+                <td>${comment.pointer}</td>
+                <td>${comment.userName}</td>
+                <td>${comment.comment}</td>
+                <td>${comment.date}</td>
+                <td>
+                    <button class="btn-danger" onclick="confirmDeleteComment('${comment.gameNumber}', ${comment.pointer})">Delete</button>
+                </td>
+            `;
+            tableBody.appendChild(row);
+        });
+    } catch (error) {
+        console.error('Failed to load comments:', error);
+        alert('Failed to load comments');
+    }
+}
+
+let pendingDeleteAction: (() => Promise<void>) | null = null;
+
+function confirmDeleteGameLog(gameNumber: string) {
+    pendingDeleteAction = async () => {
+        await deleteGameLogApi(gameNumber, adminToken!);
+        await loadGameLogs();
+    };
+    
+    const confirmMessage = document.getElementById('confirmMessage') as HTMLParagraphElement;
+    confirmMessage.textContent = `Are you sure you want to delete game log ${gameNumber}?`;
+    showConfirmDialog();
+}
+
+function confirmDeleteComment(gameNumber: string, pointer: number) {
+    pendingDeleteAction = async () => {
+        await deleteCommentApi(gameNumber, pointer, adminToken!);
+        await loadComments();
+    };
+    
+    const confirmMessage = document.getElementById('confirmMessage') as HTMLParagraphElement;
+    confirmMessage.textContent = `Are you sure you want to delete comment from game ${gameNumber}, pointer ${pointer}?`;
+    showConfirmDialog();
+}
+
+function showConfirmDialog() {
+    const confirmDialog = document.getElementById('confirmDialog') as HTMLDivElement;
+    confirmDialog.style.display = 'block';
+}
+
+function hideConfirmDialog() {
+    const confirmDialog = document.getElementById('confirmDialog') as HTMLDivElement;
+    confirmDialog.style.display = 'none';
+    pendingDeleteAction = null;
+}
+
+async function handleConfirmYes() {
+    if (pendingDeleteAction) {
+        try {
+            await pendingDeleteAction();
+            hideConfirmDialog();
+            alert('Deletion completed successfully');
+        } catch (error) {
+            console.error('Delete failed:', error);
+            alert('Deletion failed');
+        }
+    }
+}
+
+// グローバル関数として公開（HTMLから呼び出すため）
+(window as any).confirmDeleteGameLog = confirmDeleteGameLog;
+(window as any).confirmDeleteComment = confirmDeleteComment;


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.ai/code)

  実装した機能の概要

  🚀 管理者用削除機能付きパネル

  追加されたファイル:
  - public/admin.html - 管理者用Web画面
  - public/css/admin.css - 管理者画面のスタイル
  - src/server/middleware/authMiddleware.ts - Bearer token認証ミドルウェア
  - src/server/controller/authController.ts - 認証エンドポイント
  - src/webpack/screenEvent/admin/adminController.ts - 管理者画面の制御
  - src/webpack/logic/callApi/adminLogin.ts - ログインAPI呼び出し
  - src/webpack/logic/callApi/deleteGameLog.ts - ゲームログ削除API
  - src/webpack/logic/callApi/deleteComment.ts - コメント削除API
  - src/webpack/logic/callApi/getAllComments.ts - 全コメント取得API

  変更されたファイル:
  - Repository層にdelete機能追加（gameLogRepository.ts, commentRepository.ts）
  - Controller層に管理者認証付きDELETEエンドポイント追加
  - サーバー起動設定に認証エンドポイント追加

  🔐 セキュリティ機能

  - Bearer token認証（デフォルト: dominion-admin-2024）
  - 環境変数での認証設定可能
  - 管理者のみアクセス可能な削除エンドポイント

  🎯 使用方法

  1. npm run webpack でビルド
  2. npm run app-launch でサーバー起動
  3. http://localhost:3000/admin.html で管理者パネルアクセス
  4. パスワード認証後、ゲームログ・コメントの削除が可能
