### PR TITLE
Feature/cargo ship set aside

### DIFF
--- a/public/logAnalytics.html
+++ b/public/logAnalytics.html
@@ -116,6 +116,20 @@
                     <!-- データ行がここに追加されます -->
                 </tbody>
             </table>
+
+            <h3>Set Aside</h3>
+            <table id="FirstPlayerSetAsideAreaTable">
+                <thead style="text-align: left;">
+                    <tr>
+                        <th colspan="2">
+                            Set Aside
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <!-- データ行がここに追加されます -->
+                </tbody>
+            </table>
         </div>
 
         <div id="SecondPlayerSection">
@@ -153,6 +167,20 @@
                     <tr>
                         <th colspan="2">
                             Exile
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <!-- データ行がここに追加されます -->
+                </tbody>
+            </table>
+
+            <h3>Set Aside</h3>
+            <table id="SecondPlayerSetAsideAreaTable">
+                <thead style="text-align: left;">
+                    <tr>
+                        <th colspan="2">
+                            Set Aside
                         </th>
                     </tr>
                 </thead>

--- a/src/webpack/logic/logAnalyzer/logAnalyzer.ts
+++ b/src/webpack/logic/logAnalyzer/logAnalyzer.ts
@@ -14,6 +14,7 @@ import { trashes } from "./methods/trashes";
 import { gains } from "./methods/gains";
 import { exiles, discardFromExile } from "./methods/exile";
 import { returns } from "./methods/return";
+import { setAside, putInHand } from "./methods/setAside";
 
 interface logSec {
     prevLogSec: LogSectionInterface;
@@ -234,6 +235,18 @@ function analyze(
 
         case 'returns':
             returns(playerMap, playerName, cards, supply);
+            break;
+
+        case 'sets':
+            if (logSec.currentLogSec.logSection.includes('aside with')) {
+                setAside(playerMap, playerName, cards, logSec.currentLogSec.logSection);
+            }
+            break;
+
+        case 'puts':
+            if (logSec.currentLogSec.logSection.includes('in hand')) {
+                putInHand(playerMap, playerName, cards, logSec.currentLogSec.logSection);
+            }
             break;
     }
 }

--- a/src/webpack/logic/logAnalyzer/methods/setAside.ts
+++ b/src/webpack/logic/logAnalyzer/methods/setAside.ts
@@ -22,6 +22,8 @@ export function setAside(
         const cardInfo = parseCardFromText(cardToSetAside);
         if (cardInfo) {
             player.addToSetAside(cardInfo.name, cardInfo.quantity);
+            // nowInDeckからカードを減らす
+            player.decreaseFromNowInDeck(cardInfo.name, cardInfo.quantity);
         }
     }
 }
@@ -48,6 +50,8 @@ export function putInHand(
         const cardInfo = parseCardFromText(cardToPutInHand);
         if (cardInfo) {
             player.moveFromSetAsideToHand(cardInfo.name, cardInfo.quantity);
+            // nowInDeckにカードを追加
+            player.addToNowInDeck(cardInfo.name, cardInfo.quantity);
         }
     }
 }

--- a/src/webpack/logic/logAnalyzer/methods/setAside.ts
+++ b/src/webpack/logic/logAnalyzer/methods/setAside.ts
@@ -1,0 +1,74 @@
+import { Player } from "../../../model/Player";
+
+export function setAside(
+    playerMap: Map<string, Player>,
+    playerName: string,
+    cards: Array<{name: string, quantity: number}>,
+    logSection: string
+): void {
+    const player = playerMap.get(playerName);
+    if (!player) {
+        console.error(`Player ${playerName} not found.`);
+        return;
+    }
+
+    // "sets X aside with Y" パターンの解析
+    const setAsideMatch = logSection.match(/sets (.+) aside with (.+)/);
+    if (setAsideMatch) {
+        const cardToSetAside = setAsideMatch[1];
+        const sourceCard = setAsideMatch[2];
+
+        // カード名から数量を抽出（"an Ironmonger" -> "Ironmonger", 1）
+        const cardInfo = parseCardFromText(cardToSetAside);
+        if (cardInfo) {
+            player.addToSetAside(cardInfo.name, cardInfo.quantity);
+        }
+    }
+}
+
+export function putInHand(
+    playerMap: Map<string, Player>,
+    playerName: string,
+    cards: Array<{name: string, quantity: number}>,
+    logSection: string
+): void {
+    const player = playerMap.get(playerName);
+    if (!player) {
+        console.error(`Player ${playerName} not found.`);
+        return;
+    }
+
+    // "puts X in hand (Y)" パターンの解析
+    const putInHandMatch = logSection.match(/puts (.+) in hand \((.+)\)/);
+    if (putInHandMatch) {
+        const cardToPutInHand = putInHandMatch[1];
+        const sourceCard = putInHandMatch[2];
+
+        // カード名から数量を抽出
+        const cardInfo = parseCardFromText(cardToPutInHand);
+        if (cardInfo) {
+            player.moveFromSetAsideToHand(cardInfo.name, cardInfo.quantity);
+        }
+    }
+}
+
+function parseCardFromText(text: string): {name: string, quantity: number} | null {
+    // "an Ironmonger" -> {name: "Ironmonger", quantity: 1}
+    // "2 Estates" -> {name: "Estate", quantity: 2}
+    
+    const quantityMatch = text.match(/^(\d+)\s+(.+)/);
+    if (quantityMatch) {
+        const quantity = parseInt(quantityMatch[1]);
+        const cardName = quantityMatch[2].replace(/s$/, ''); // 複数形を単数形に変換
+        return {name: cardName, quantity};
+    }
+
+    const articleMatch = text.match(/^(a|an)\s+(.+)/i);
+    if (articleMatch) {
+        const cardName = articleMatch[2];
+        return {name: cardName, quantity: 1};
+    }
+
+    // 記事なしの場合は1枚として扱う
+    return {name: text, quantity: 1};
+}

--- a/src/webpack/model/Player.ts
+++ b/src/webpack/model/Player.ts
@@ -13,6 +13,7 @@ export class Player {
     private turnExiles: Map<string, number> = new Map(); // ターン中に追放した合計枚数
     
     private exileArea: Map<string, number> = new Map();  // 現在の追放エリアの状況
+    private setAsideArea: Map<string, number> = new Map(); // 現在のset-asideエリアの状況
 
     private playerName: string = '';
     private turn: number = 0; // 現在のターン数
@@ -40,6 +41,7 @@ export class Player {
         player.totalExiles = new Map(Array.from(this.totalExiles.entries()).map(([key, card]) => [key, card]));
         player.turnExiles = new Map(Array.from(this.turnExiles.entries()).map(([key, card]) => [key, card]));
         player.exileArea = new Map(Array.from(this.exileArea.entries()).map(([key, card]) => [key, card]));
+        player.setAsideArea = new Map(Array.from(this.setAsideArea.entries()).map(([key, card]) => [key, card]));
         player.playerName = this.playerName;
         player.turn = this.turn;
         return player;
@@ -225,6 +227,34 @@ export class Player {
     // ゲーム中に追放した合計枚数を取得するメソッド
     getTotalExiles(): Map<string, number> {
         return this.totalExiles;
+    }
+
+    // set-asideエリアを取得するメソッド
+    getSetAsideArea(): Map<string, number> {
+        return this.setAsideArea;
+    }
+
+    // set-asideエリアに新しいカードを追加するメソッド
+    addToSetAside(cardName: string, count: number): void {
+        const existingCard = this.setAsideArea.get(cardName);
+        if (existingCard) {
+            this.setAsideArea.set(cardName, existingCard + count);
+        } else {
+            this.setAsideArea.set(cardName, count);
+        }
+    }
+
+    // set-asideエリアからカードを手札に戻すメソッド
+    moveFromSetAsideToHand(cardName: string, count: number): void {
+        const existingCard = this.setAsideArea.get(cardName);
+        if (existingCard && existingCard >= count) {
+            this.setAsideArea.set(cardName, existingCard - count);
+            if (this.setAsideArea.get(cardName) === 0) {
+                this.setAsideArea.delete(cardName);
+            }
+        } else {
+            console.error(`Not enough "${cardName}" in set-aside area to move to hand.`);
+        }
     }
 
     // プレイヤー名を取得するメソッド

--- a/src/webpack/screenEvent/logAnalitics/updateScreen.ts
+++ b/src/webpack/screenEvent/logAnalitics/updateScreen.ts
@@ -352,6 +352,32 @@ function updatePlayerArea(
             }
         });
     }
+
+    // Set-asideエリアテーブルの更新
+    const setAsideTableElement = playerSwitch === 1 ? 'FirstPlayerSetAsideAreaTable' : 'SecondPlayerSetAsideAreaTable';
+    const playerSetAsideTableBody = document.getElementById(setAsideTableElement)?.getElementsByTagName('tbody')[0];
+    if (playerSetAsideTableBody) {
+        // テーブルのリセット
+        while (playerSetAsideTableBody.firstChild) {
+            playerSetAsideTableBody.removeChild(playerSetAsideTableBody.firstChild);
+        }
+
+        // テーブルの再描画
+        player.getSetAsideArea().forEach((count, name) => {
+            const row = playerSetAsideTableBody.insertRow();
+            const cell1 = row.insertCell(0);
+            const cell2 = row.insertCell(1);
+            cell1.textContent = name;
+            cell2.textContent = count.toString();
+
+            // 増減したカードの背景色を変更
+            const prevCount = prevPlayer.getSetAsideArea().get(name) || 0;
+            cell2.style.backgroundColor = getBackgroundColor(count, prevCount);
+            if (count !== prevCount) {
+                cell2.textContent = prevCount + "→" + count;
+            }
+        });
+    }
 }
 
 


### PR DESCRIPTION
## 概要
- Add setAsideArea management to Player class for tracking cards set aside by Duration effects
- Implement setAside.ts methods to parse "sets X aside with Y" and "puts X in hand (Y)" patterns
- Add logAnalyzer support for 'sets' and 'puts' verb processing
- Enable proper tracking of Cargo Ship and other Duration card effects

🤖 Generated with [Claude Code](https://claude.ai/code)

## 関連issue

## 変更点

## 影響範囲

## 補足
